### PR TITLE
Redirect naked domain

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,3 @@
 /doc/1.0/*         /doc/:splat
+http://sweetjs.org  https://www.sweetjs.org
+https://sweetjs.org https://www.sweetjs.org


### PR DESCRIPTION
This should allow us to force TLS (I think the cert is on www so https://sweetjs.org without a redirect has a cert error)