### PR TITLE
Repositories are prefixed with `sweet`

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -14,7 +14,7 @@ Macros allow you to sweeten the syntax of JavaScript and craft the language youâ
 Install Sweet with npm:
 
 ```sh
-$ npm install -g @sweet-js/cli @sweet-js/helpers
+$ npm install -g @sweet-js/sweet-cli @sweet-js/sweet-helpers
 ```
 
 This globally installs the `sjs` binary, which is used to compile Sweet code.


### PR DESCRIPTION
Prior to this modification yarn would fail:

```
mlaw$ yarn add --dev sweet-js/cli sweet-js/helpers
Using globally installed version of Yarn
yarn add v1.12.1
(node:40449) ExperimentalWarning: The fs.promises API is experimental
info No lockfile found.
[1/4] 🔍  Resolving packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads ssh://git@github.com/sweet-js/cli.git
Directory: /Users/mlaw/dev/strut2
Output:
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```